### PR TITLE
Downgrade firebase crashlytics dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.5"
         classpath 'com.google.gms:google-services:4.3.15'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.5'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.2'
 
         // Updating to 2.0.0 causes error. Manifest merger failed.
         classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.2.0"


### PR DESCRIPTION
Temporary fix for firebase crashlytics dependency. Version 2.9.5 would not generate signed bundle. Downgrading to version 2.9.2 fixes issue.