### PR TITLE
Improvements to traffic map alert refresh

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    implementation 'com.google.android.material:material:1.8.0'
+    implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.activity:activity-ktx:1.5.0'
     implementation 'androidx.fragment:fragment-ktx:1.5.7'
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.5.1'
@@ -98,9 +98,9 @@ dependencies {
     implementation 'com.google.android.gms:play-services-maps:18.1.0'
 
     implementation 'com.google.firebase:firebase-core:21.1.1'
-    implementation 'com.google.firebase:firebase-analytics:21.2.2'
+    implementation 'com.google.firebase:firebase-analytics:21.3.0'
     implementation 'com.google.firebase:firebase-messaging:23.1.2'
-    implementation 'com.google.firebase:firebase-crashlytics-ktx:18.3.6'
+    implementation 'com.google.firebase:firebase-crashlytics-ktx:18.3.7'
 
     implementation 'androidx.appcompat:appcompat:1.4.2'
     implementation 'androidx.core:core-ktx:1.8.0'

--- a/app/src/main/java/gov/wa/wsdot/android/wsdot/ui/trafficmap/TrafficMapFragment.kt
+++ b/app/src/main/java/gov/wa/wsdot/android/wsdot/ui/trafficmap/TrafficMapFragment.kt
@@ -1058,12 +1058,11 @@ class TrafficMapFragment : DaggerFragment(), Injectable, OnMapReadyCallback,
         item?.let {
             when(it.itemId) {
                 R.id.action_refresh -> {
+
+                    mapHighwayAlertsViewModel.setAlertQuery(mMap.projection.visibleRegion.latLngBounds, false)
+                    mapCamerasViewModel.setCameraQuery(mMap.projection.visibleRegion.latLngBounds, false)
                     mapHighwayAlertsViewModel.refresh()
                     mapCamerasViewModel.refresh()
-
-                    // Center camera position to activate markers
-                    val center = mMap.cameraPosition
-                    mMap.moveCamera(CameraUpdateFactory.newCameraPosition(center))
 
                     if (this::toast.isInitialized)
                     {

--- a/app/src/main/java/gov/wa/wsdot/android/wsdot/ui/trafficmap/TrafficMapFragment.kt
+++ b/app/src/main/java/gov/wa/wsdot/android/wsdot/ui/trafficmap/TrafficMapFragment.kt
@@ -111,6 +111,7 @@ class TrafficMapFragment : DaggerFragment(), Injectable, OnMapReadyCallback,
     var showMountainPasses: Boolean = true
     var requestLocationUpgrade: Boolean = true
     var goToLocation: Boolean = true
+    private var alertQueryTask: Boolean = false
 
     private lateinit var mMap: GoogleMap
 
@@ -143,9 +144,17 @@ class TrafficMapFragment : DaggerFragment(), Injectable, OnMapReadyCallback,
     private lateinit var mapUpdateHandler: Handler
     private val alertsUpdateTask = object: Runnable {
         override fun run() {
-            mapHighwayAlertsViewModel.setAlertQuery(mMap.projection.visibleRegion.latLngBounds, false)
-            mapHighwayAlertsViewModel.refresh()
+
+            if (alertQueryTask) {
+                mapHighwayAlertsViewModel.setAlertQuery(
+                    mMap.projection.visibleRegion.latLngBounds,
+                    false
+                )
+            }
+                mapHighwayAlertsViewModel.refresh()
             mapUpdateHandler.postDelayed(this, 300000)
+            alertQueryTask = true
+
         }
     }
 
@@ -285,6 +294,7 @@ class TrafficMapFragment : DaggerFragment(), Injectable, OnMapReadyCallback,
         mapUpdateHandler.removeCallbacks(alertsUpdateTask)
 
         t?.cancel()
+        alertQueryTask = false
 
     }
 

--- a/app/src/main/java/gov/wa/wsdot/android/wsdot/ui/trafficmap/TrafficMapFragment.kt
+++ b/app/src/main/java/gov/wa/wsdot/android/wsdot/ui/trafficmap/TrafficMapFragment.kt
@@ -143,6 +143,7 @@ class TrafficMapFragment : DaggerFragment(), Injectable, OnMapReadyCallback,
     private lateinit var mapUpdateHandler: Handler
     private val alertsUpdateTask = object: Runnable {
         override fun run() {
+            mapHighwayAlertsViewModel.setAlertQuery(mMap.projection.visibleRegion.latLngBounds, false)
             mapHighwayAlertsViewModel.refresh()
             mapUpdateHandler.postDelayed(this, 300000)
         }


### PR DESCRIPTION
- Auto refresh traffic map alerts while map is inactive. 
- Improves responsiveness of refresh button when map is inactive. 
- Dependency updates.

Development Environment
- Macbook Pro (Apple M1 Pro)
- Mac OS Ventura: 13.4
- Android Studio Flamingo | 2022.2.1 Patch 2