### PR TITLE
Revert "Update Firebase Crashalytics to 3.0.3"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,7 @@ android {
             firebaseCrashlytics {
                 nativeSymbolUploadEnabled true
                 // These paths are relative to the app/ folder
+                strippedNativeLibsDir "build/ndklibs/obj"
                 unstrippedNativeLibsDir "build/ndklibs/libs"
             }
             shrinkResources true

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         // Updating to 4.4.0 causes crash when selecting notification check box.
         classpath 'com.google.gms:google-services:4.3.15'
 
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.3'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.9'
 
         // Updating to 2.0.0 causes error. Manifest merger failed.
         classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.2.0"


### PR DESCRIPTION
This reverts commit a435e1a8ffc64283ce0559ac032179fd3b52ccd3.

Crashlytics Gradle plugin 3 requires Google-Services 4.4.1 and above.