### PR TITLE
Revert Bumptech Glide Dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -147,9 +147,11 @@ dependencies {
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
     // Glide - https://github.com/bumptech/glide
+    // Updating to v5.0.5 causes a crash on Android 6.0 (SDK 23)
     implementation 'com.github.bumptech.glide:glide:4.11.0'
 
     // Library supports using KSP instead of kapt
+    // Updating to v5.0.5 causes a crash on Android 6.0 (SDK 23)
     kapt 'com.github.bumptech.glide:compiler:4.11.0'
 
     // gson


### PR DESCRIPTION
- Updating Bumptech Glide dependency to v5.0.5 causes a crash on Android 6.0 (SDK 23)

------------------------------

Development Environment
- Macbook Pro (Apple M1 Pro)
- Mac OS Tahoe: 26.0.1
- Android Studio Narwhal | 2025.1.1 Patch 1