### PR TITLE
Revert "Enable R8 app optimization"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,4 @@ android.lifecycleProcessor.incremental=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+android.enableR8.fullMode=false


### PR DESCRIPTION
Enabling R8 app optimization causes errors while building the APK.

This reverts commit 5bcee02427084cf10ae0d6bdae59e3cf85e17636.
